### PR TITLE
Allow to use scope codes

### DIFF
--- a/Console/Command/ThemeChangeCommand.php
+++ b/Console/Command/ThemeChangeCommand.php
@@ -4,17 +4,19 @@ namespace Yireo\ThemeCommands\Console\Command;
 
 use Magento\Framework\App\Cache\Manager as CacheManager;
 use Magento\Framework\App\ScopeResolverPool;
-use Magento\Framework\View\Design\Theme\ListInterface;
-use Magento\Indexer\Model\Indexer;
 use Magento\Indexer\Model\IndexerFactory;
+use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
+use Magento\Store\Model\StoreFactory as StoreModelFactory;
+use Magento\Store\Model\ResourceModel\Website as WebsiteResourceModel;
+use Magento\Store\Model\WebsiteFactory as WebsiteModelFactory;
 use Magento\Theme\Model\ResourceModel\Theme as ThemeResourceModel;
 use Magento\Theme\Model\ThemeFactory as ThemeModelFactory;
-use Magento\Theme\Model\Theme;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Throwable;
 
 class ThemeChangeCommand extends Command
 {
@@ -24,6 +26,10 @@ class ThemeChangeCommand extends Command
     private IndexerFactory $indexerFactory;
     private ThemeResourceModel $themeResourceModel;
     private ThemeModelFactory $themeFactory;
+    private WebsiteResourceModel $websiteResourceModel;
+    private WebsiteModelFactory $websiteFactory;
+    private StoreResourceModel $storeResourceModel;
+    private StoreModelFactory $storeFactory;
 
     public function __construct(
         ScopeResolverPool $scopeResolverPool,
@@ -32,6 +38,10 @@ class ThemeChangeCommand extends Command
         IndexerFactory $indexerFactory,
         ThemeResourceModel $themeResourceModel,
         ThemeModelFactory $themeFactory,
+        WebsiteResourceModel $websiteResourceModel,
+        WebsiteModelFactory $websiteFactory,
+        StoreResourceModel $storeResourceModel,
+        StoreModelFactory $storeFactory,
         string $name = null
     ) {
         parent::__construct($name);
@@ -41,12 +51,16 @@ class ThemeChangeCommand extends Command
         $this->indexerFactory = $indexerFactory;
         $this->themeResourceModel = $themeResourceModel;
         $this->themeFactory = $themeFactory;
+        $this->websiteResourceModel = $websiteResourceModel;
+        $this->websiteFactory = $websiteFactory;
+        $this->storeResourceModel = $storeResourceModel;
+        $this->storeFactory = $storeFactory;
     }
 
     /**
      * Initialization of the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('theme:change');
         $this->setDescription('Change a StoreView to use a specific theme');
@@ -62,14 +76,13 @@ class ThemeChangeCommand extends Command
      * @param InputInterface $input
      * @param OutputInterface $output
      *
-     * @return void
+     * @return int
+     * @throws Throwable
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $themeName = trim($input->getArgument('theme_name'));
-        $themeModel = $this->themeFactory->create();
-        $this->themeResourceModel->load($themeModel, $themeName, 'theme_path');
-        $themeId = $themeModel->getId();
+        $themeId = $this->getThemeId($themeName);
 
         if (!$themeId > 0) {
             $output->writeln('<error>Not a valid theme: ' . $themeName . '</error>');
@@ -87,14 +100,50 @@ class ThemeChangeCommand extends Command
             $scope = 'default';
         }
 
+        if (!is_numeric($scopeId)) {
+            switch ($scope) {
+                case 'websites':
+                    $scopeId = $this->getWebsiteId($scopeId);
+                    break;
+                case 'stores':
+                    $scopeId = $this->getStoreId($scopeId);
+                    break;
+            }
+        }
+
+        if (!$scopeId > 0) {
+            $output->writeln('<error>Not a valid scopeId: ' . $scopeId . '</error>');
+            return Command::FAILURE;
+        }
+
         $this->config->saveConfig('design/theme/theme_id', $themeId, $scope, $scopeId);
         $this->cacheManager->clean(['config', 'layout', 'block_html']);
 
-        /** @var Indexer $indexer */
         $indexer = $this->indexerFactory->create();
         $indexer->load('design_config_grid');
         $indexer->reindexAll();
 
         return Command::SUCCESS;
+    }
+
+    private function getThemeId(string $themeName): int
+    {
+        $themeModel = $this->themeFactory->create();
+        $this->themeResourceModel->load($themeModel, $themeName, 'theme_path');
+        return (int)$themeModel->getId();
+    }
+
+    private function getWebsiteId(string $scopeId): int
+    {
+        $websiteModel = $this->websiteFactory->create();
+        $this->websiteResourceModel->load($websiteModel, $scopeId, 'code');
+        return (int)$websiteModel->getId();
+    }
+
+    private function getStoreId(string $scopeId): int
+    {
+        $storeModel = $this->storeFactory->create();
+        $this->storeResourceModel->load($storeModel, $scopeId, 'code');
+        return (int)$storeModel->getId();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "yireo/magento2-theme-commands",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "OSL-3.0",
   "description": "CLI commands to manipulate themes",
   "type": "magento2-module",


### PR DESCRIPTION
It's nice to be able to also use store/website codes instead of their ids only.

I have introduced a backward compatible change which converts scope codes into their ids if non numeric values are provided.
So that besides:
```
bin/magento theme:change Hyva/default <store_id> stores
```
we can now also use:
```
bin/magento theme:change Hyva/default <store_code> stores
```